### PR TITLE
Bumped unity package for Rider support to 3.0.17

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.collab-proxy": "1.17.1",
-    "com.unity.ide.rider": "3.0.15",
+    "com.unity.ide.rider": "3.0.17",
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.4.4",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -17,7 +17,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.15",
+      "version": "3.0.17",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Change package version from `3.0.15` to `3.0.17`

![image](https://user-images.githubusercontent.com/44952199/211315030-525c89ee-c3bb-413f-97f2-02db5d790cc9.png)
