### PR TITLE
Add Null Check for Components

### DIFF
--- a/Assets/Prefabs/Environment/Boost Crate.prefab
+++ b/Assets/Prefabs/Environment/Boost Crate.prefab
@@ -146,7 +146,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18ddaa8b2a7da8c4e8cd379679d963bf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _boost: {fileID: 187741752577437644, guid: 3b61dd29d483b5b44ae7d9296d7da664, type: 3}
+  _boost: {fileID: 7368286474336530193, guid: 3b61dd29d483b5b44ae7d9296d7da664, type: 3}
 --- !u!114 &-6817648966148636139
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Heroes/Characters/Bonni.prefab
+++ b/Assets/Prefabs/Heroes/Characters/Bonni.prefab
@@ -1,36 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &2098699420421557160
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 846497453633432339}
-  m_Layer: 3
-  m_Name: Footsteps Sound
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &846497453633432339
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2098699420421557160}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6942594267589458436}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2886871588467311804
 GameObject:
   m_ObjectHideFlags: 0
@@ -190,7 +159,6 @@ GameObject:
   - component: {fileID: 4779849879955402722}
   - component: {fileID: 3024373830178429953}
   - component: {fileID: 6855535888617466851}
-  - component: {fileID: 3623703019395178509}
   m_Layer: 3
   m_Name: Bonni
   m_TagString: Untagged
@@ -215,7 +183,7 @@ Transform:
   - {fileID: 5902166961514092591}
   - {fileID: 3433570077077697961}
   - {fileID: 7632048028256500891}
-  - {fileID: 846497453633432339}
+  - {fileID: 178458586924644856}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -600,7 +568,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weapon: {fileID: 1613903837751180537}
-  _ultimate: {fileID: 3623703019395178509}
+  _ultimate: {fileID: 1383474856757340531}
 --- !u!114 &1307913016
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -849,25 +817,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!114 &3623703019395178509
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6942594267589458447}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6a55805d1a6e0e742b0073288e24ac60, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _canBeUsed: 0
-  _cooldown: 10
-  _onUse: {fileID: 11400000, guid: 6365880e29c1acb478df347cf660ed17, type: 2}
-  _onReady: {fileID: 11400000, guid: fd58774d0cfd2244fab7022c71190b7c, type: 2}
-  _ascendSpeed: 20
-  _ascendDuration: 1
-  _flyDuration: 5
 --- !u!1 &7632048028256500890
 GameObject:
   m_ObjectHideFlags: 0
@@ -1330,3 +1279,76 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5450649732138452598, guid: c18962be4e926424083f4db3348b50b4, type: 3}
   m_PrefabInstance: {fileID: 7206573894488077279}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8053781805556594547
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6942594267589458436}
+    m_Modifications:
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8473342498592253556, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+      propertyPath: m_Name
+      value: Flying Ultimate
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+--- !u!4 &178458586924644856 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7907974333387411083, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+  m_PrefabInstance: {fileID: 8053781805556594547}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1383474856757340531 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9004895695236292096, guid: 091f88f56ee8d1c44888ae1e81e64225, type: 3}
+  m_PrefabInstance: {fileID: 8053781805556594547}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a55805d1a6e0e742b0073288e24ac60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Heroes/Characters/Carl.prefab
+++ b/Assets/Prefabs/Heroes/Characters/Carl.prefab
@@ -190,7 +190,6 @@ GameObject:
   - component: {fileID: 4779849879955402722}
   - component: {fileID: 3024373830178429953}
   - component: {fileID: 6855535888617466851}
-  - component: {fileID: 4425911836799265497}
   m_Layer: 3
   m_Name: Carl
   m_TagString: Untagged
@@ -216,6 +215,7 @@ Transform:
   - {fileID: 6812773931409237469}
   - {fileID: 7632048028256500891}
   - {fileID: 846497453633432339}
+  - {fileID: 3768913118243798781}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -600,7 +600,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weapon: {fileID: 6398484084056586541}
-  _ultimate: {fileID: 4425911836799265497}
+  _ultimate: {fileID: 98768420081605036}
 --- !u!114 &1307913016
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -849,30 +849,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!114 &4425911836799265497
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6942594267589458447}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2e3ec037adc3334f9959d866c32839b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _canBeUsed: 0
-  _cooldown: 10
-  _onUse: {fileID: 11400000, guid: 6365880e29c1acb478df347cf660ed17, type: 2}
-  _onReady: {fileID: 11400000, guid: fd58774d0cfd2244fab7022c71190b7c, type: 2}
-  _hitLayers:
-    serializedVersion: 2
-    m_Bits: 776
-  _ultimateDuration: 7
-  _speed: 20
-  _timeBetweenHits: 1
-  _damagePerHit: 4
-  _hitRadius: 3
 --- !u!1 &7632048028256500890
 GameObject:
   m_ObjectHideFlags: 0
@@ -1330,4 +1306,77 @@ MonoBehaviour:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4477687935517241812, guid: c1d1aef3c517491468ce18aad9cef0e4, type: 3}
   m_PrefabInstance: {fileID: 6964857229157520393}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8493099869689559908
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6942594267589458436}
+    m_Modifications:
+    - target: {fileID: 1318796846451780646, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_Name
+      value: Speed Ultimate
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+--- !u!114 &98768420081605036 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8395668546519999176, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+  m_PrefabInstance: {fileID: 8493099869689559908}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2e3ec037adc3334f9959d866c32839b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &3768913118243798781 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4724368189662168473, guid: 9f11356a84d889a4f8923cdb7d749434, type: 3}
+  m_PrefabInstance: {fileID: 8493099869689559908}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Heroes/Characters/Dinomike.prefab
+++ b/Assets/Prefabs/Heroes/Characters/Dinomike.prefab
@@ -190,7 +190,6 @@ GameObject:
   - component: {fileID: 4779849879955402722}
   - component: {fileID: 3024373830178429953}
   - component: {fileID: 6855535888617466851}
-  - component: {fileID: 4705892112748762171}
   m_Layer: 3
   m_Name: Dinomike
   m_TagString: Untagged
@@ -217,6 +216,7 @@ Transform:
   - {fileID: 8875820040749194292}
   - {fileID: 7632048028256500891}
   - {fileID: 846497453633432339}
+  - {fileID: 945046064983605878}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -601,7 +601,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weapon: {fileID: 1613903837751180537}
-  _ultimate: {fileID: 4705892112748762171}
+  _ultimate: {fileID: 4823024477433606124}
 --- !u!114 &1307913016
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -850,23 +850,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!114 &4705892112748762171
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6942594267589458447}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e8242a368eb64422984d1dde07340eb5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _canBeUsed: 0
-  _cooldown: 10
-  _onUse: {fileID: 11400000, guid: 6365880e29c1acb478df347cf660ed17, type: 2}
-  _onReady: {fileID: 11400000, guid: fd58774d0cfd2244fab7022c71190b7c, type: 2}
-  _weapon: {fileID: 4823072056508290404}
 --- !u!1 &7632048028256500890
 GameObject:
   m_ObjectHideFlags: 0
@@ -1244,6 +1227,83 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 679646ae9fb21124e902ab33f4e8c3a2, type: 3}
   m_PrefabInstance: {fileID: 1125899177775471265}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1575577339601062642
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6942594267589458436}
+    m_Modifications:
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6283436322902385950, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: _weapon
+      value: 
+      objectReference: {fileID: 4823072056508290404}
+    - target: {fileID: 7352767474091393370, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+      propertyPath: m_Name
+      value: Weapon Upgrade Ultimate
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+--- !u!4 &945046064983605878 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1783682040439834756, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+  m_PrefabInstance: {fileID: 1575577339601062642}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4823024477433606124 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6283436322902385950, guid: b5d81b9f9e712ea4eb37d248977de380, type: 3}
+  m_PrefabInstance: {fileID: 1575577339601062642}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e8242a368eb64422984d1dde07340eb5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3497509381519891010
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Heroes/Characters/Poko.prefab
+++ b/Assets/Prefabs/Heroes/Characters/Poko.prefab
@@ -190,7 +190,6 @@ GameObject:
   - component: {fileID: 4779849879955402722}
   - component: {fileID: 3024373830178429953}
   - component: {fileID: 6855535888617466851}
-  - component: {fileID: 893425918932318370}
   m_Layer: 3
   m_Name: Poko
   m_TagString: Untagged
@@ -216,6 +215,7 @@ Transform:
   - {fileID: 6725021624933941768}
   - {fileID: 7632048028256500891}
   - {fileID: 846497453633432339}
+  - {fileID: 6414212177703195047}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -600,7 +600,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weapon: {fileID: 1248349949804028787}
-  _ultimate: {fileID: 893425918932318370}
+  _ultimate: {fileID: 8801428031076788076}
 --- !u!114 &1307913016
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -849,23 +849,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!114 &893425918932318370
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6942594267589458447}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54fad06762f81c74ca6a031f9538ed2b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _canBeUsed: 0
-  _cooldown: 10
-  _onUse: {fileID: 11400000, guid: 6365880e29c1acb478df347cf660ed17, type: 2}
-  _onReady: {fileID: 11400000, guid: fd58774d0cfd2244fab7022c71190b7c, type: 2}
-  _healingPointsPercent: 50
 --- !u!1 &7632048028256500890
 GameObject:
   m_ObjectHideFlags: 0
@@ -1324,3 +1307,76 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8156460348731439143, guid: 57a83ca9f4eb2c542a5cba000966bda9, type: 3}
   m_PrefabInstance: {fileID: 3199107083722045999}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4508586733648217072
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6942594267589458436}
+    m_Modifications:
+    - target: {fileID: 5591393323788147691, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_Name
+      value: Healing Ultimate
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+--- !u!4 &6414212177703195047 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7463146567388615255, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+  m_PrefabInstance: {fileID: 4508586733648217072}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8801428031076788076 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4950937679678891164, guid: a3b8e08e35771f44c9c43a838075a64e, type: 3}
+  m_PrefabInstance: {fileID: 4508586733648217072}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54fad06762f81c74ca6a031f9538ed2b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/Abilities/DashAbility.cs
+++ b/Assets/Scripts/Abilities/DashAbility.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Misc;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -16,7 +17,7 @@ namespace Abilities
 
         private void Awake()
         {
-            _rigidbody = GetComponent<Rigidbody>();
+            _rigidbody = this.GetComponentWithNullCheck<Rigidbody>();
         }
 
         public void Update()

--- a/Assets/Scripts/Battlefield/BattleFieldBuilder.cs
+++ b/Assets/Scripts/Battlefield/BattleFieldBuilder.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using Misc;
 using UnityEngine;
 using UnityEngine.AI;
-using UnityEngine.Serialization;
 using Random = System.Random;
 
 namespace Battlefield
@@ -25,6 +24,12 @@ namespace Battlefield
         private List<Hero> Heroes { get; set; } = new();
         private BattleField _map;
         readonly Random _rnd = new Random();
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_wall, _grass, _bottle, _ground);
+        }
+        
         private void Start()
         {
             BuildTerrain();

--- a/Assets/Scripts/Bot/BotCombat.cs
+++ b/Assets/Scripts/Bot/BotCombat.cs
@@ -1,6 +1,5 @@
-﻿using Combat;
+﻿using System;
 using Combat.Weapons;
-using JetBrains.Annotations;
 using Misc;
 using Ultimates;
 using UnityEngine;
@@ -11,6 +10,12 @@ namespace Bot
     {
         [SerializeField] private Weapon _weapon;
         [SerializeField] private Ultimate _ultimate;
+
+        private void OnValidate()
+        {
+            this.CheckIfNull(_weapon);
+            this.CheckIfNull(_ultimate);
+        }
 
         public void Shoot(Hero hero)
         {

--- a/Assets/Scripts/Bot/BotController.cs
+++ b/Assets/Scripts/Bot/BotController.cs
@@ -17,9 +17,9 @@ namespace Bot
 
         private void Awake()
         {
-            _botMovement = GetComponent<BotMovement>();
-            _botSensor = GetComponent<BotSensor>();
-            _botCombat = GetComponent<BotCombat>();
+            _botMovement = this.GetComponentWithNullCheck<BotMovement>();
+            _botSensor = this.GetComponentWithNullCheck<BotSensor>();
+            _botCombat = this.GetComponentWithNullCheck<BotCombat>();
         }
 
         private void Update()

--- a/Assets/Scripts/Bot/BotMovement.cs
+++ b/Assets/Scripts/Bot/BotMovement.cs
@@ -1,10 +1,12 @@
 ﻿using Events;
+using Misc;
 using UnityEngine;
 using UnityEngine.AI;
 using Random = UnityEngine.Random;
 
 namespace Bot
 {
+    [RequireComponent(typeof(NavMeshAgent))]
     public class BotMovement : MonoBehaviour
     {
         [Header("Random Point")]
@@ -34,10 +36,15 @@ namespace Bot
                 _agent.speed = value;
             }
         }
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_onMove, _onStopMoving);
+        }
 
         private void Awake()
         {
-            _agent = GetComponent<NavMeshAgent>();
+            _agent = this.GetComponentWithNullCheck<NavMeshAgent>();
         }
 
         private void Start()

--- a/Assets/Scripts/CharacterSelection/ButtonCharacterName.cs
+++ b/Assets/Scripts/CharacterSelection/ButtonCharacterName.cs
@@ -1,4 +1,5 @@
-﻿using TMPro;
+﻿using Misc;
+using TMPro;
 using UnityEngine;
 
 namespace CharacterSelection
@@ -10,7 +11,7 @@ namespace CharacterSelection
 
         private void Awake()
         {
-            _textMeshPro = GetComponent<TextMeshProUGUI>();
+            _textMeshPro = this.GetComponentWithNullCheck<TextMeshProUGUI>();
         }
 
         public void SetText(Component component, object data)

--- a/Assets/Scripts/CharacterSelection/CameraMovement.cs
+++ b/Assets/Scripts/CharacterSelection/CameraMovement.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System;
+using Misc;
+using UnityEngine;
 
 namespace CharacterSelection
 {
@@ -12,6 +14,12 @@ namespace CharacterSelection
 
         private float _elapsedTime;
         private bool _isDelayComplete;
+
+        private void OnValidate()
+        {
+            this.CheckIfNull(_startPosition, _endPosition);
+            this.CheckIfNull(_canvas);
+        }
 
         private void Start()
         {

--- a/Assets/Scripts/Combat/Health.cs
+++ b/Assets/Scripts/Combat/Health.cs
@@ -1,4 +1,5 @@
 using Events;
+using Misc;
 using Models;
 using UnityEngine;
 
@@ -12,6 +13,11 @@ namespace Combat
         
         [SerializeField] private GameEvent _onDeath;
         [SerializeField] private GameEvent _onHealthChanged;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_onDeath, _onHealthChanged);
+        }
 
         private void Start()
         {

--- a/Assets/Scripts/Combat/Projectiles/Bomb.cs
+++ b/Assets/Scripts/Combat/Projectiles/Bomb.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using Misc;
+using UnityEngine;
 
 namespace Combat.Projectiles
 {
@@ -9,6 +10,12 @@ namespace Combat.Projectiles
         [SerializeField, Min(0)] private float _timeToExplode = 3f;
         [SerializeField, Min(0)] private float _damage = 20f;
         [SerializeField, Min(0)] private float _explosionRadius = 5f;
+
+        private void OnValidate()
+        {
+            this.CheckIfNull(_hitLayers);
+            this.CheckIfNull(_explosion);
+        }
 
         private void Start()
         {

--- a/Assets/Scripts/Combat/Projectiles/Bullet.cs
+++ b/Assets/Scripts/Combat/Projectiles/Bullet.cs
@@ -1,3 +1,4 @@
+using Misc;
 using UnityEngine;
 
 namespace Combat.Projectiles
@@ -9,8 +10,12 @@ namespace Combat.Projectiles
         [SerializeField, Min(0)] private float _maxDistance = 100f;
         [SerializeField, Min(0)] private float _damage = 5f;
         
-
         private Vector3 _oldPosition;
+
+        private void OnValidate()
+        {
+            this.CheckIfNull(_hitLayers);
+        }
 
         private void Start()
         {

--- a/Assets/Scripts/Combat/Projectiles/RigidbodyProjectile.cs
+++ b/Assets/Scripts/Combat/Projectiles/RigidbodyProjectile.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System;
+using Misc;
+using UnityEngine;
 
 namespace Combat.Projectiles
 {
@@ -9,7 +11,7 @@ namespace Combat.Projectiles
         
         private void Awake()
         {
-            _rigidbody = GetComponent<Rigidbody>();
+            _rigidbody = this.GetComponentWithNullCheck<Rigidbody>();
         }
         
         public void SetVelocity(Vector3 velocity)

--- a/Assets/Scripts/Combat/Weapons/BallisticGun.cs
+++ b/Assets/Scripts/Combat/Weapons/BallisticGun.cs
@@ -1,4 +1,5 @@
 using Combat.Projectiles;
+using Misc;
 using UnityEngine;
 
 namespace Combat.Weapons
@@ -11,6 +12,13 @@ namespace Combat.Weapons
         [Header("Settings")]
         [SerializeField, Min(0)] private float _throwPower = 10f;
         [SerializeField, Range(0, 2)] private float _heroVelocityInfluence = 0.5f;
+
+        protected override void OnValidate()
+        {
+            this.CheckIfNull(_rigidbody);
+            
+            base.OnValidate();
+        }
 
         protected override void Shoot()
         {

--- a/Assets/Scripts/Combat/Weapons/Gun.cs
+++ b/Assets/Scripts/Combat/Weapons/Gun.cs
@@ -1,4 +1,5 @@
 ﻿using Combat.Projectiles;
+using Misc;
 using UnityEngine;
 
 namespace Combat.Weapons
@@ -13,6 +14,12 @@ namespace Combat.Weapons
         [SerializeField] protected float _bulletSpawnDistance = 1f;
         [SerializeField] protected float _bulletSpawnHeight = 0.5f;
         
+        protected virtual void OnValidate()
+        {
+            this.CheckIfNull(_projectile);
+            this.CheckIfNull(_shootingDirection);
+        }
+
         protected override void Use()
         {
             Shoot();

--- a/Assets/Scripts/Combat/Weapons/Knife.cs
+++ b/Assets/Scripts/Combat/Weapons/Knife.cs
@@ -1,3 +1,4 @@
+using Misc;
 using UnityEngine;
 
 namespace Combat.Weapons
@@ -15,6 +16,13 @@ namespace Combat.Weapons
         [SerializeField, Min(0)] private float _radius = 0.5f;
         [SerializeField, Min(0)] private float _length = 0.5f;
         [SerializeField] private Vector3 _hitOffset;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_lookDirection);
+            this.CheckIfNull(_hitLayers);
+            this.CheckIfNull(_hitOffset);
+        }
 
         protected override void Use()
         {

--- a/Assets/Scripts/Environment/Crate.cs
+++ b/Assets/Scripts/Environment/Crate.cs
@@ -1,10 +1,16 @@
+using Misc;
 using UnityEngine;
 
 namespace Environment
 {
     public class Crate : MonoBehaviour
     {
-        [SerializeField] private GameObject _boost;
+        [SerializeField] private Boost _boost;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_boost);
+        }
 
         public void OnDie(Component component, object data)
         {

--- a/Assets/Scripts/Events/GameEventListener.cs
+++ b/Assets/Scripts/Events/GameEventListener.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Misc;
 using UnityEngine;
 
 namespace Events
@@ -7,6 +8,12 @@ namespace Events
     {
         [SerializeField] private GameEvent _gameEvent;
         [SerializeField] private CustomUnityEvent _response;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_gameEvent);
+            this.CheckIfNull(_response);
+        }
 
         private void OnEnable()
         {

--- a/Assets/Scripts/Hud/EnemiesLeftText.cs
+++ b/Assets/Scripts/Hud/EnemiesLeftText.cs
@@ -1,4 +1,5 @@
-﻿using TMPro;
+﻿using Misc;
+using TMPro;
 using UnityEngine;
 
 namespace Hud
@@ -6,6 +7,11 @@ namespace Hud
     public class EnemiesLeftText : MonoBehaviour
     {
         [SerializeField] private TextMeshProUGUI _text;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_text);
+        }
 
         public void SetEnemiesLeft(Component component, object data)
         {

--- a/Assets/Scripts/Hud/HealthBar.cs
+++ b/Assets/Scripts/Hud/HealthBar.cs
@@ -1,3 +1,4 @@
+using Misc;
 using Models;
 using Player;
 using TMPro;
@@ -10,6 +11,12 @@ namespace Hud
     {
         [SerializeField] private Image _bar;
         [SerializeField] private TextMeshProUGUI _text;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_bar);
+            this.CheckIfNull(_text);
+        }
 
         public void SetHealthBar(Component component, object data) 
         {

--- a/Assets/Scripts/Menu/SettingsSaver.cs
+++ b/Assets/Scripts/Menu/SettingsSaver.cs
@@ -1,4 +1,5 @@
 using System;
+using Misc;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -8,6 +9,11 @@ namespace Menu
     public class SettingsSaver : MonoBehaviour
     {
         [SerializeField] private string _settingsKey;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_settingsKey);
+        }
 
         private void Start()
         {

--- a/Assets/Scripts/Misc/ComponentExtensions.cs
+++ b/Assets/Scripts/Misc/ComponentExtensions.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+
+namespace Misc
+{
+    public static class ComponentExtensions
+    {
+        public static void CheckIfNull<T>(this Component self, T componentToCheck)
+        {
+            if (componentToCheck == null && self.gameObject.scene.name != null)
+            {
+                Debug.LogError($"{typeof(T).Name} is null for {self.GetType().Name} on GameObject: {self.gameObject.name} " +
+                               $"(Path: {self.gameObject.transform.GetHierarchyPath()}, Position: {self.gameObject.transform.position})");
+            }
+        }
+        
+        public static void CheckIfNull<T>(this Component self, params T[] objectsToCheck)
+        {
+            if (self.gameObject.scene.name == null)
+            {
+                return;
+            }
+            
+            foreach (var obj in objectsToCheck)
+            {
+                if (obj == null)
+                {
+                    Debug.LogError($"{typeof(T).Name} is null for {self.GetType().Name} on GameObject: {self.gameObject.name} " +
+                                   $"(Path: {self.gameObject.transform.GetHierarchyPath()}, Position: {self.gameObject.transform.position})");
+                }
+            }
+        }
+        
+        public static T GetComponentWithNullCheck<T>(this Component self) where T : Component
+        {
+            var component = self.GetComponent<T>();
+            if (component == null)
+            {
+                Debug.LogError($"{typeof(T).Name} is null for {self.GetType().Name} on GameObject: {self.gameObject.name} " +
+                               $"(Path: {self.gameObject.transform.GetHierarchyPath()}, Position: {self.gameObject.transform.position})");
+            }
+            return component;
+        }
+        
+        public static T GetComponentInParentWithNullCheck<T>(this Component self) where T : Component
+        {
+            var component = self.GetComponentInParent<T>();
+            if (component == null)
+            {
+                Debug.LogError($"{typeof(T).Name} is null for {self.GetType().Name} on GameObject: {self.gameObject.name} " +
+                               $"(Path: {self.gameObject.transform.GetHierarchyPath()}, Position: {self.gameObject.transform.position})");
+            }
+            return component;
+        }
+
+    }
+}

--- a/Assets/Scripts/Misc/ComponentExtensions.cs.meta
+++ b/Assets/Scripts/Misc/ComponentExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c51b4cb08f8c42c4a99a0ccfb137094e
+timeCreated: 1684259762

--- a/Assets/Scripts/Misc/GroundChecker.cs
+++ b/Assets/Scripts/Misc/GroundChecker.cs
@@ -16,6 +16,13 @@ namespace Misc
 
         public bool IsGrounded { get; private set; }
         private bool _wasGrounded = false;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_groundCheck);
+            this.CheckIfNull(_groundMask);
+            this.CheckIfNull(_onLand, _onAirborne);
+        }
 
         private void Update()
         {

--- a/Assets/Scripts/Misc/Hero.cs
+++ b/Assets/Scripts/Misc/Hero.cs
@@ -10,5 +10,11 @@ namespace Misc
         public Vector3 ShootAt => _shootAt.position;
         
         public string Name => _name;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_shootAt);
+            this.CheckIfNull(_name);
+        }
     }
 }

--- a/Assets/Scripts/Misc/HeroesPool.cs
+++ b/Assets/Scripts/Misc/HeroesPool.cs
@@ -14,6 +14,11 @@ namespace Misc
 
         public List<Hero> Heroes { get; private set; } = new();
         
+        private void OnValidate()
+        {
+            this.CheckIfNull(_onHeroesAmountChanged);
+        }
+        
         private void Start()
         {
             _onHeroesAmountChanged.Raise(this, Heroes.Count);

--- a/Assets/Scripts/Misc/TransformExtensions.cs
+++ b/Assets/Scripts/Misc/TransformExtensions.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+
+namespace Misc
+{
+    public static class TransformExtensions
+    {
+        public static string GetHierarchyPath(this Transform transform)
+        {
+            string path = transform.name;
+            while (transform.parent != null)
+            {
+                transform = transform.parent;
+                path = transform.name + "/" + path;
+            }
+            return path;
+        }
+    }
+}

--- a/Assets/Scripts/Misc/TransformExtensions.cs.meta
+++ b/Assets/Scripts/Misc/TransformExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: aa56067d0377444c93330a14b4010fb4
+timeCreated: 1684259264

--- a/Assets/Scripts/Player/AnimationStateController.cs
+++ b/Assets/Scripts/Player/AnimationStateController.cs
@@ -22,10 +22,10 @@ namespace Player
 
         private void Awake()
         {
-            _animator = GetComponent<Animator>();
-            _playerMovement = GetComponent<PlayerMovement>();
-            _playerJump = GetComponent<PlayerJump>();
-            _groundChecker = GetComponent<GroundChecker>();
+            _animator = this.GetComponentWithNullCheck<Animator>();
+            _playerMovement = this.GetComponentWithNullCheck<PlayerMovement>();
+            _playerJump = this.GetComponentWithNullCheck<PlayerJump>();
+            _groundChecker = this.GetComponentWithNullCheck<GroundChecker>();
         }
 
         private void Update()

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Combat.Weapons;
+using Misc;
 using Ultimates;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -11,11 +12,11 @@ namespace Player
         [Header("Requirements")]
         [SerializeField] private Weapon _weapon;
         [SerializeField] private Ultimate _ultimate;
-
-        private void Start()
+        
+        private void OnValidate()
         {
-            if (_weapon is null) Debug.LogError("Weapon is null for " + gameObject.name);
-            if (_ultimate is null) Debug.LogError("Ultimate is null for " + gameObject.name);
+            this.CheckIfNull(_weapon);
+            this.CheckIfNull(_ultimate);
         }
 
         public void OnShoot(InputAction.CallbackContext context)

--- a/Assets/Scripts/Player/PlayerJump.cs
+++ b/Assets/Scripts/Player/PlayerJump.cs
@@ -21,10 +21,15 @@ namespace Player
         private Rigidbody _rigidbody;
         private GroundChecker _groundChecker;
 
+        private void OnValidate()
+        {
+            this.CheckIfNull(_onJump);
+        }
+        
         private void Start()
         {
-            _rigidbody = GetComponent<Rigidbody>();
-            _groundChecker = GetComponent<GroundChecker>();
+            _rigidbody = this.GetComponentWithNullCheck<Rigidbody>();
+            _groundChecker = this.GetComponentWithNullCheck<GroundChecker>();
         }
 
         private void FixedUpdate()

--- a/Assets/Scripts/Player/PlayerJump.cs
+++ b/Assets/Scripts/Player/PlayerJump.cs
@@ -26,7 +26,7 @@ namespace Player
             this.CheckIfNull(_onJump);
         }
         
-        private void Start()
+        private void Awake()
         {
             _rigidbody = this.GetComponentWithNullCheck<Rigidbody>();
             _groundChecker = this.GetComponentWithNullCheck<GroundChecker>();

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -39,7 +39,7 @@ namespace Player
             this.CheckIfNull(_onMove, _onStopMoving, _onSneak, _onStopSneaking);
         }
 
-        private void Start()
+        private void Awake()
         {
             _rigidbody = this.GetComponentWithNullCheck<Rigidbody>();
             _groundChecker = this.GetComponentWithNullCheck<GroundChecker>();

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -33,11 +33,16 @@ namespace Player
             get => _walkSpeed;
             set => _walkSpeed = value;
         }
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_onMove, _onStopMoving, _onSneak, _onStopSneaking);
+        }
 
         private void Start()
         {
-            _rigidbody = GetComponent<Rigidbody>();
-            _groundChecker = GetComponent<GroundChecker>();
+            _rigidbody = this.GetComponentWithNullCheck<Rigidbody>();
+            _groundChecker = this.GetComponentWithNullCheck<GroundChecker>();
         }
 
         private void Update()

--- a/Assets/Scripts/Sound/FootstepsSound.cs
+++ b/Assets/Scripts/Sound/FootstepsSound.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Misc;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
@@ -24,10 +25,16 @@ namespace Sound
         private int _previousFootstepIndex = -1;
 
         private const string SettingsKey = "volume";
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_jumpSound);
+            this.CheckIfNull(_landingSound);
+        }
 
         private void Awake()
         {
-            _audioSource = GetComponent<AudioSource>();
+            _audioSource = this.GetComponentWithNullCheck<AudioSource>();
             _footstepDelay = _footstepWalkDelay;
         }
 

--- a/Assets/Scripts/Sound/WeaponSound.cs
+++ b/Assets/Scripts/Sound/WeaponSound.cs
@@ -1,3 +1,4 @@
+using Misc;
 using UnityEngine;
 
 namespace Sound
@@ -7,6 +8,12 @@ namespace Sound
         [Header("Requirements")]
         [SerializeField] private AudioClip _sound;
         [SerializeField] private AudioSource _audioSource;
+        
+        private void OnValidate()
+        {
+            this.CheckIfNull(_sound);
+            this.CheckIfNull(_audioSource);
+        }
 
         public void PlaySound(Component component, object data)
         {

--- a/Assets/Scripts/Ultimates/FlyingUltimate.cs
+++ b/Assets/Scripts/Ultimates/FlyingUltimate.cs
@@ -15,11 +15,8 @@ namespace Ultimates
 
         private void Awake()
         {
-            _rigidbody = GetComponentInParent<Rigidbody>();
-            if (_rigidbody is null) Debug.LogError("Rigidbody is null for " + gameObject.name); 
-            
-            _groundChecker = GetComponentInParent<GroundChecker>();
-            if (_groundChecker is null) Debug.LogError("GroundChecker is null for " + gameObject.name);
+            _rigidbody = this.GetComponentInParentWithNullCheck<Rigidbody>();
+            _groundChecker = this.GetComponentInParentWithNullCheck<GroundChecker>();
         }
 
         protected override void Use()

--- a/Assets/Scripts/Ultimates/HealingUltimate.cs
+++ b/Assets/Scripts/Ultimates/HealingUltimate.cs
@@ -1,4 +1,5 @@
 using Combat;
+using Misc;
 using UnityEngine;
 
 namespace Ultimates
@@ -11,8 +12,7 @@ namespace Ultimates
         
         private void Awake()
         {
-            _health = GetComponentInParent<Health>();
-            if (_health is null) Debug.LogError("Health is null for " + gameObject.name);
+            _health = this.GetComponentInParentWithNullCheck<Health>();
         }
 
         protected override void Use()

--- a/Assets/Scripts/Ultimates/SpeedUltimate.cs
+++ b/Assets/Scripts/Ultimates/SpeedUltimate.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using Combat;
+using Misc;
 using Player;
 using UnityEngine;
 
@@ -16,11 +17,17 @@ namespace Ultimates
         [SerializeField, Min(0)] private float _hitRadius = 3f;
     
         private PlayerMovement _playerMovement;
+        
+        protected override void OnValidate()
+        {
+            this.CheckIfNull(_hitLayers);
+            
+            base.OnValidate();
+        }
 
         private void Awake()
         {
-            _playerMovement = GetComponentInParent<PlayerMovement>();
-            if (_playerMovement is null) Debug.LogError("PlayerMovement is null for " + gameObject.name);
+            _playerMovement = this.GetComponentInParentWithNullCheck<PlayerMovement>();
         }
 
         protected override void Use()

--- a/Assets/Scripts/Ultimates/Ultimate.cs
+++ b/Assets/Scripts/Ultimates/Ultimate.cs
@@ -1,4 +1,5 @@
 ﻿using Events;
+using Misc;
 using UnityEngine;
 
 namespace Ultimates
@@ -13,6 +14,11 @@ namespace Ultimates
         [SerializeField] protected GameEvent _onReady;
 
         private bool _canBeUsed = false;
+        
+        protected virtual void OnValidate()
+        {
+            this.CheckIfNull(_onUse, _onReady);
+        }
         
         private void Start()
         {

--- a/Assets/Scripts/Ultimates/WeaponUpgradeUltimate.cs
+++ b/Assets/Scripts/Ultimates/WeaponUpgradeUltimate.cs
@@ -1,4 +1,5 @@
 ﻿using Combat.Weapons;
+using Misc;
 using UnityEngine;
 
 namespace Ultimates
@@ -7,10 +8,12 @@ namespace Ultimates
     {
         [Header("Requirements")]
         [SerializeField] private Weapon _weapon;
-
-        protected void Awake()
+        
+        protected override void OnValidate()
         {
-            if (_weapon is null) Debug.LogError("Weapon is null for " + gameObject.name);
+            this.CheckIfNull(_weapon);
+            
+            base.OnValidate();
         }
 
         protected override void Use()


### PR DESCRIPTION
## Usage for field with [SerializeField]

Add `OnValidate` method:
```
[SerializeField] private Weapon _weapon;

private void OnValidate()
{
    this.CheckIfNull(_weapon);
}
```

Multiple fields of **same type** can be passed together:
```
[SerializeField] private GameEvent _onDeath;
[SerializeField] private GameEvent _onHealthChanged;

private void OnValidate()
{
    this.CheckIfNull(_onDeath, _onHealthChanged);
}
```

## Usage for field without [SerializeField]

Instead of:
```
_rigidbody = GetComponent<Rigidbody>();
```

Use:
```
_rigidbody = this.GetComponentWithNullCheck<Rigidbody>();
```

Same thing with **InParent**.
Instead of:
```
_rigidbody = GetComponentInParent<Rigidbody>();
```

Use:
```
_rigidbody = this.GetComponentInParentWithNullCheck<Rigidbody>();
```

## Result

This approach will send error log if component is null
![image](https://github.com/TheCreators/BrawlBorne/assets/44952199/edcbff4c-cdce-424c-8742-230062e24d6f)

1. Fields with [SerializeField] will be checked after **each code update** (even if game is not started) and after **game start**.
2. Fields without [SerializeField] will be checked after **game start**. 